### PR TITLE
Change readers to work on Stream of Bytes instead.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,14 @@ tokio = { version = "1", features = ["time"], optional = true }
 tokio-util = { version = "0.6", optional = true }
 pin-project = { version = "1.0", optional = true }
 futures = { version = "0.3", optional = true }
+bytes = { version = "1.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["fs", "macros", "parking_lot", "rt-multi-thread"] }
+futures-util = { version = "0.3", features = ["io"] }
 
 [features]
 utils = ["futures"]
-util_readers = ["sha1", "tokio", "tokio-util", "pin-project", "reqwest/stream"]
+util_readers = ["sha1", "tokio", "tokio-util", "pin-project", "bytes", "reqwest/stream"]
 
 default = ["utils", "util_readers"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,10 @@ bytes = { version = "1.0", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["fs", "macros", "parking_lot", "rt-multi-thread"] }
 futures-util = { version = "0.3", features = ["io"] }
+reqwest = { version = "0.11", features = ["stream"] }
 
 [features]
 utils = ["futures"]
-util_readers = ["sha1", "tokio", "tokio-util", "pin-project", "bytes", "reqwest/stream"]
+util_readers = ["sha1", "tokio", "tokio-util", "pin-project", "bytes"]
 
 default = ["utils", "util_readers"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,11 +31,11 @@
 //!         last_modified_millis: modf,
 //!     };
 //!
-//!     let reader = file;
-//!     let reader = AsyncReadHashAtEnd::wrap(reader);
-//!     let reader = AsyncReadThrottled::wrap(reader, 5000);
-//!     let body = body_from_reader(reader);
-//!
+//!     let stream = reader_to_stream(file);
+//!     let stream = BytesStreamHashAtEnd::wrap(stream);
+//!     let stream = BytesStreamThrottled::wrap(stream, 5000);
+//!     
+//!     let body = reqwest::Body::wrap_stream(stream);
 //!     let resp1 = b2_upload_file(&client, &upauth, body, param).await.unwrap();
 //!
 //!     let resp2 = b2_delete_file_version(&client, &auth, &resp1.file_name, &resp1.file_id.unwrap()).await.unwrap();

--- a/src/utils/readers.rs
+++ b/src/utils/readers.rs
@@ -1,96 +1,93 @@
 ///! Different `Read` wrappers, useful for file uploading.
 ///! These can be composed to combine their effects
-use futures::ready;
+use bytes::Bytes;
+use futures::{ready, Stream, TryStreamExt};
 use pin_project::pin_project;
 use sha1::Sha1;
-use std::cmp::min;
+use std::io::Error as IoError;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::{
-    io::{AsyncRead, ReadBuf},
+    io::AsyncRead,
     time::{Instant, Sleep},
 };
 use tokio_util::codec::{BytesCodec, FramedRead};
 
-/// Wraps an `AsyncRead`, computing the Sha1 hash along the way and returning it when the inner reader is done
+/// Wraps an [Stream] of [Result<Bytes, std::io::Error>], computing the Sha1 hash along the way and returning it when the inner stream is done
 ///
 /// The hash is returned as 40 hexadecimal digits
-
 #[pin_project]
-pub struct AsyncReadHashAtEnd<R: AsyncRead> {
+pub struct BytesStreamHashAtEnd<R>
+where
+    R: Stream<Item = Result<Bytes, IoError>>,
+{
     #[pin]
     inner: R,
     hash: Sha1,
-    hash_read: usize,
+    done: bool,
 }
 
-impl<R: AsyncRead> AsyncReadHashAtEnd<R> {
-    pub fn wrap(reader: R) -> Self {
+impl<R> BytesStreamHashAtEnd<R>
+where
+    R: Stream<Item = Result<Bytes, IoError>>,
+{
+    pub fn wrap(inner: R) -> Self {
         Self {
-            inner: reader,
+            inner,
             hash: Sha1::new(),
-            hash_read: 0,
+            done: false,
         }
     }
 }
 
-impl<R: AsyncRead> AsyncRead for AsyncReadHashAtEnd<R> {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
+impl<R> Stream for BytesStreamHashAtEnd<R>
+where
+    R: Stream<Item = Result<Bytes, IoError>>,
+{
+    type Item = Result<Bytes, IoError>;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
-        let before_filled_len = buf.filled().len();
-        ready!(this.inner.poll_read(cx, buf))?;
-        let after_filled = buf.filled();
-        let read_amount = after_filled.len() - before_filled_len;
-        let hash_read = *this.hash_read;
-        // If the inner AsyncRead is still returning data, hash the data.
-        if read_amount > 0 {
-            this.hash.update(&after_filled[before_filled_len..]);
-        }
-        // If EOF is reached but we haven't write all 40 bytes of the hash yet, write the hash.
-        else if hash_read < 40 {
-            let digest = this.hash.hexdigest();
-            let digest = digest.as_bytes();
-
-            let remaining = buf.remaining();
-
-            // 1. If the buffer isn't large enough for our hash, we need to split it up OR
-            // 2. If we've already sent part of the hash, we need to only return the remainder
-            if remaining < 40 || hash_read > 0 {
-                // Determine how much we can return (in case the buffer is too small)
-                let hash_end_index = min(40, hash_read + remaining);
-                let hash_read_amount = hash_end_index - hash_read;
-
-                buf.put_slice(&digest[hash_read..hash_end_index]);
-                *this.hash_read += hash_read_amount;
-            } else {
-                // If there's enough room, just send the 40-byte hexdigest directly
-                buf.put_slice(&digest);
-                *this.hash_read = 40;
+        let bytes: Option<Result<Bytes, IoError>> = ready!(this.inner.poll_next(cx));
+        match bytes {
+            Some(Ok(bytes)) => {
+                this.hash.update(&bytes);
+                Poll::Ready(Some(Ok(bytes)))
             }
+            None => {
+                if !*this.done {
+                    let digest = this.hash.hexdigest();
+                    let digest_bytes = Bytes::copy_from_slice(digest.as_bytes());
+                    *this.done = true;
+                    Poll::Ready(Some(Ok(digest_bytes)))
+                } else {
+                    Poll::Ready(None)
+                }
+            }
+            other => Poll::Ready(other),
         }
-        Poll::Ready(Ok(()))
     }
 }
 
-/// Wraps an `AsyncRead`, limiting the bandwidth it can use. \
+/// Wraps an [Stream] of [Result<Bytes, std::io::Error>], limiting the bandwidth it can use. \
 /// Useful for limiting upload bandwidth.
 ///
 /// bandwidth: maximum bytes per second \
-
 #[pin_project]
-pub struct AsyncReadThrottled<R: AsyncRead> {
+pub struct BytesStreamThrottled<R>
+where
+    R: Stream<Item = Result<Bytes, IoError>>,
+{
     #[pin]
     inner: R,
     bandwidth: f32,
     sleep: Pin<Box<Sleep>>,
 }
 
-impl<R: AsyncRead> AsyncReadThrottled<R> {
+impl<R> BytesStreamThrottled<R>
+where
+    R: Stream<Item = Result<Bytes, IoError>>,
+{
     pub fn wrap(reader: R, bandwidth: usize) -> Self {
         Self {
             inner: reader,
@@ -100,44 +97,50 @@ impl<R: AsyncRead> AsyncReadThrottled<R> {
     }
 }
 
-impl<R: AsyncRead> AsyncRead for AsyncReadThrottled<R> {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
+impl<R> Stream for BytesStreamThrottled<R>
+where
+    R: Stream<Item = Result<Bytes, IoError>>,
+{
+    type Item = Result<Bytes, IoError>;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         use futures::Future;
         let this = self.project();
         ready!(this.sleep.as_mut().poll(cx));
-        let before_rmn = buf.remaining();
-        ready!(this.inner.poll_read(cx, buf))?;
-        let after_rmn = buf.remaining();
-        let read_amount = before_rmn - after_rmn;
-        let sleep_duration: f32 = (read_amount as f32) / *this.bandwidth;
-        this.sleep
-            .as_mut()
-            .reset(Instant::now() + Duration::from_secs_f32(sleep_duration));
-        Poll::Ready(Ok(()))
+        let res: Option<Result<Bytes, IoError>> = ready!(this.inner.poll_next(cx));
+        if let Some(Ok(bytes)) = &res {
+            let read_amount = bytes.len();
+            let sleep_duration: f32 = (read_amount as f32) / *this.bandwidth;
+            this.sleep
+                .as_mut()
+                .reset(Instant::now() + Duration::from_secs_f32(sleep_duration));
+        }
+        Poll::Ready(res)
     }
 }
 
-/// Wrap an [AsyncRead] into a [reqwest::Body].
-pub fn body_from_reader<R: AsyncRead + Send + Sync + 'static>(file: R) -> reqwest::Body {
-    let stream = FramedRead::new(file, BytesCodec::new());
-    reqwest::Body::wrap_stream(stream)
+/// Wrap an [AsyncRead] into a [Stream] of [Result<Bytes, IoError>].
+pub fn reader_to_stream<R: AsyncRead + Send + Sync + 'static>(
+    file: R,
+) -> impl Stream<Item = Result<Bytes, IoError>> {
+    let stream = FramedRead::new(file, BytesCodec::new()).map_ok(bytes::BytesMut::freeze);
+    stream
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
+    use futures::AsyncReadExt;
+
     use super::*;
 
     #[tokio::test]
     async fn test_read_hash_at_end() {
-        use tokio::io::AsyncReadExt;
+        use futures_util::TryStreamExt;
         let content = "hello this is a test".as_bytes();
-        let mut read = AsyncReadHashAtEnd::wrap(content);
+        let stream = reader_to_stream(content);
+        let stream = BytesStreamHashAtEnd::wrap(stream);
+        let mut read = stream.into_async_read();
         let mut buf = Vec::new();
         read.read_to_end(&mut buf).await.unwrap();
         let l = buf.len();
@@ -156,16 +159,14 @@ mod tests {
     #[tokio::test]
     async fn test_thrrottled_read() {
         // Test reading 512 bytes at a bandwidth of 256 bytes / sec. Should complete in around 2 secs.
-        use tokio::io::AsyncReadExt;
+        use futures::TryStreamExt;
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("tests/resources/512bytes.txt");
         let file = tokio::fs::File::open(&path).await.unwrap();
-        let mut read = AsyncReadThrottled::wrap(file, 256);
-        let mut buf: Vec<u8> = vec![0; 512];
+        let stream = reader_to_stream(file);
+        let stream = BytesStreamThrottled::wrap(stream, 256);
         let start = Instant::now();
-        for chunk in buf.chunks_mut(16) {
-            read.read_exact(chunk).await.unwrap();
-        }
+        let _res: Vec<Bytes> = stream.try_collect().await.unwrap();
         let end = Instant::now();
         let elapsed = (end - start).as_secs_f32();
         let expected = 2f32;

--- a/tests/basic_usage_tests.rs
+++ b/tests/basic_usage_tests.rs
@@ -33,10 +33,11 @@ async fn test_basic_usage() {
     };
 
     let reader = file;
-    let reader = AsyncReadHashAtEnd::wrap(reader);
-    let reader = AsyncReadThrottled::wrap(reader, 20000);
+    let reader = reader_to_stream(reader);
+    let reader = BytesStreamHashAtEnd::wrap(reader);
+    let reader = BytesStreamThrottled::wrap(reader, 20000);
 
-    let resp1 = b2_upload_file(&client, &upauth, body_from_reader(reader), param).await;
+    let resp1 = b2_upload_file(&client, &upauth, reqwest::Body::wrap_stream(reader), param).await;
 
     let resp1 = resp1.unwrap();
     assert_eq!(


### PR DESCRIPTION
I've tried using `b2_upload_file` in my server and found working with Stream of Bytes more suitable than AsyncRead. Most server provides incoming request body as Stream of Bytes. Reqwest itself takes TryStream of Bytes to stream uploading. Wrapping Stream of Bytes into AsyncRead and back seems inefficient.

In this PR I change the readers utils to work on TryStream of Bytes instead of AsyncRead, and provide a function to convert the latter to the former.

Let me know what you think.

